### PR TITLE
Update existingSecret to accept resources for initContainer

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: "file://charts/common"
     version: 1.10.x
 home: https://www.openldap.org
-version: 4.1.1
+version: 4.1.2
 appVersion: 2.6.3
 description: Community developed LDAP software
 icon: https://raw.githubusercontent.com/jp-gouin/helm-openldap/master/logo.png

--- a/charts/ltb-passwd/templates/_helpers.tpl
+++ b/charts/ltb-passwd/templates/_helpers.tpl
@@ -48,7 +48,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Generate chart secret name
 */}}
 {{- define "ltb-passwd.secretName" -}}
-{{ default (include "ltb-passwd.fullname" .) .Values.global.existingSecret  }}
+{{ default (include "ltb-passwd.fullname" .) .Values.existingSecret.name  }}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Create the name of the service account to use
 Generate chart secret name
 */}}
 {{- define "openldap.secretName" -}}
-{{ default (include "openldap.fullname" .) .Values.global.existingSecret }}
+{{ default (include "openldap.fullname" .) .Values.existingSecret.name }}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Generate olcSyncRepl list
 {{- $name := (include "openldap.fullname" .) }}
 {{- $namespace := .Release.Namespace }}
 {{- $cluster := .Values.replication.clusterName }}
-{{- $configPassword :=  ternary .Values.global.configPassword "%%CONFIG_PASSWORD%%" (not .Values.existingSecret.enabled ) }}
+{{- $configPassword :=  ternary .Values.global.configPassword "%%CONFIG_PASSWORD%%" (not .Values.existingSecret.enabled) }}
 {{- $retry := .Values.replication.retry }}
 {{- $timeout := .Values.replication.timeout }}
 {{- $starttls := .Values.replication.starttls }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Generate olcSyncRepl list
 {{- $name := (include "openldap.fullname" .) }}
 {{- $namespace := .Release.Namespace }}
 {{- $cluster := .Values.replication.clusterName }}
-{{- $configPassword :=  ternary .Values.global.configPassword "%%CONFIG_PASSWORD%%" (empty .Values.global.existingSecret) }}
+{{- $configPassword :=  ternary .Values.global.configPassword "%%CONFIG_PASSWORD%%" (not .Values.existingSecret.enabled ) }}
 {{- $retry := .Values.replication.retry }}
 {{- $timeout := .Values.replication.timeout }}
 {{- $starttls := .Values.replication.starttls }}
@@ -90,7 +90,7 @@ Generate olcSyncRepl list
 {{- $domain := (include "global.baseDomain" .) }}
 {{- $namespace := .Release.Namespace }}
 {{- $cluster := .Values.replication.clusterName }}
-{{- $adminPassword := ternary .Values.global.adminPassword "%%ADMIN_PASSWORD%%" (empty .Values.global.existingSecret) }}
+{{- $adminPassword := ternary .Values.global.adminPassword "%%ADMIN_PASSWORD%%" (not .Values.existingSecret.enabled) }}
 {{- $retry := .Values.replication.retry }}
 {{- $timeout := .Values.replication.timeout }}
 {{- $starttls := .Values.replication.starttls }}

--- a/templates/secret-ltb.yaml
+++ b/templates/secret-ltb.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.global.existingSecret }}
+{{ if not .Values.existingSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.global.existingSecret }}
+{{ if not .Values.existingSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -57,8 +57,8 @@ spec:
               {{- if .Values.customTLS.caPEMContent }}
               cp -vLr /tmp-certs-ca/* /certs
               {{- end }}
-          {{- if .Values.initResources }}
-          resources: {{- toYaml .Values.initResources | nindent 12 }}
+          {{- if .Values.customTLS.resources }}
+          resources: {{- toYaml .Values.customTLS.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: certs

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -57,8 +57,8 @@ spec:
               {{- if .Values.customTLS.caPEMContent }}
               cp -vLr /tmp-certs-ca/* /certs
               {{- end }}
-          {{- if .Values.customTLS.resources }}
-          resources: {{- toYaml .Values.customTLS.resources | nindent 12 }}
+          {{- if .Values.initResources }}
+          resources: {{- toYaml .Values.initResources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: certs
@@ -97,6 +97,9 @@ spec:
               ls -al /custom_config
               sed -i -e "s/%%CONFIG_PASSWORD%%/${LDAP_CONFIG_ADMIN_PASSWORD}/g" /custom_config/*
               sed -i -e "s/%%ADMIN_PASSWORD%%/${LDAP_ADMIN_PASSWORD}/g" /custom_config/*
+          {{- if .Values.initResources }}
+          resources: {{- toYaml .Values.initResources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: cm-replication-acls
               mountPath: "/cm-schemas-acls"

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
             - name: foo
               mountPath: bar
       {{- end }}
-      {{- if .Values.global.existingSecret }}
+      {{- if .Values.existingSecret.enabled }}
         - name: update-replication
           image: {{ include "openldap.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -97,9 +97,7 @@ spec:
               ls -al /custom_config
               sed -i -e "s/%%CONFIG_PASSWORD%%/${LDAP_CONFIG_ADMIN_PASSWORD}/g" /custom_config/*
               sed -i -e "s/%%ADMIN_PASSWORD%%/${LDAP_ADMIN_PASSWORD}/g" /custom_config/*
-          {{- if .Values.initResources }}
-          resources: {{- toYaml .Values.initResources | nindent 12 }}
-          {{- end }}
+          resources: {{- toYaml .Values.existingSecret.resources | nindent 12 }}
           volumeMounts:
             - name: cm-replication-acls
               mountPath: "/cm-schemas-acls"
@@ -255,7 +253,7 @@ spec:
             claimName: {{ .Values.persistence.existingClaim }}
 {{- end }}
 {{- end }}
-{{- if .Values.global.existingSecret }}
+{{- if .Values.existingSecret.enabled }}
         - name: cm-replication-acls
           configMap:
             name: {{ template "openldap.fullname" . }}-replication-acls

--- a/values.yaml
+++ b/values.yaml
@@ -227,6 +227,11 @@ customStartupProbe: {}
 resources:
   limits: {}
   requests: {}
+
+initResources:
+  limits: {}
+  requests: {}
+
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled OPENLDAP  pods' Security Context

--- a/values.yaml
+++ b/values.yaml
@@ -14,8 +14,6 @@ global:
   #imagePullSecrets: [""]
   ## ldapDomain , can be explicit (e.g dc=toto,c=ca) or domain based (e.g example.com)
   ldapDomain: "example.org"
-  # Specifies an existing secret to be used for admin and config user passwords. The expected key are LDAP_ADMIN_PASSWORD and LDAP_CONFIG_ADMIN_PASSWORD.
-  # existingSecret: ""
   ## Default Passwords to use, stored as a secret. Not used if existingSecret is set.
   adminPassword:  Not@SecurePassw0rd
   configPassword: Not@SecurePassw0rd
@@ -45,6 +43,14 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+
+# Specifies an existing secret to be used for admin and config user passwords. The expected key are LDAP_ADMIN_PASSWORD and LDAP_CONFIG_ADMIN_PASSWORD.
+existingSecret:
+  enabled: false
+  name: ""
+  resources:
+    limits: {}
+    requests: {}
 
 replicaCount: 3
 
@@ -225,10 +231,6 @@ customStartupProbe: {}
 ## @param resources.requests The requested resources for the OPENLDAP  containers
 ##
 resources:
-  limits: {}
-  requests: {}
-
-initResources:
   limits: {}
   requests: {}
 


### PR DESCRIPTION
### What this PR does / why we need it
When using `existingSecret`, an additional initContainer is created to replace the password values with the values located in the Secret. However, this container does not have any resources defined and our resource quota requires it.

This change extends `existingSecret` and allows for resources to be defined for the initContainer