### PR TITLE
Update how we are loading the syncprov module

### DIFF
--- a/templates/configmap-replication-acls.yaml
+++ b/templates/configmap-replication-acls.yaml
@@ -19,8 +19,8 @@ data:
   syncprov.ldif: |
     # Load syncprov module
     dn: cn=module{0},cn=config
-    objectClass: olcModuleList
-    cn: module{0}
+    changetype: modify
+    add: olcModuleLoad
     olcModuleLoad: syncprov
   serverid.ldif: |
     # Set server ID


### PR DESCRIPTION
### What this PR does / why we need it:

- Updates how we are loading syncprov module as it throws an error if any module is already using the module{0} slot before we try to load syncprov. This change allows us to append syncprov to the module{0} slot and proceed without errors. These errors occur when trying to use the openldap bitnami 2.5.18 image.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you updated the readme?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss open a ticket first**